### PR TITLE
Add channel type for PR and CI messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ CRON_SCHEDULE='0 8-18 * * 1-5'  # 매 정시 실행, 주중(월~금) 8시부터 
 # 프로젝트 실행
 docker-compose up -d
 
+# DB 초기화 또는 스키마 변경 적용
+docker-compose run --rm db-init
+
 # 로그 확인
 docker-compose logs -f
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ CRON_SCHEDULE='0 8-18 * * 1-5'  # 매 정시 실행, 주중(월~금) 8시부터 
   - pr_reviews: PR 리뷰 정보
   - github_action_events: GitHub Actions 실행 결과
   - crawler_status: 크롤링 상태 정보
+  - mattermost_channels: Mattermost 채널 정보 (channel_type 컬럼을 통해 PR 채널과 CI/CD 채널을 구분)
 
 ### 4. API (PostgREST)
 - 데이터베이스 REST API 제공

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,21 @@ services:
       timeout: 5s
       retries: 5
 
+  db-init:
+    image: postgres:latest
+    env_file:
+      - .env
+    environment:
+      PGPASSWORD: ${POSTGRES_PASSWORD}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - ./postgres/init.sql:/init.sql
+    entrypoint: /bin/sh
+    command: -c "psql -h postgres -U $POSTGRES_USER -d $POSTGRES_DB -f /init.sql"
+    restart: 'no'
+
   postgrest:
     container_name: postgrest
     image: postgrest/postgrest:latest

--- a/mattermost-notifier/src/mattermostNotifier.ts
+++ b/mattermost-notifier/src/mattermostNotifier.ts
@@ -75,7 +75,7 @@ class MattermostNotifier {
                 short: false
             }
         ];
-        await this.sendMattermostMessage({ text: message, fields });
+        await this.sendMattermostMessage({ text: message, fields }, 'pr');
         await this.markAsNotified('pr_events', pr.id);
     }
     console.log(`[${this.getKSTTime()}] notifyNewPRs 완료`);
@@ -121,7 +121,7 @@ class MattermostNotifier {
                 short: false
             }
         ];
-        await this.sendMattermostMessage({ text: message, fields });
+        await this.sendMattermostMessage({ text: message, fields }, 'pr');
         await this.markAsNotified('pr_events', pr.id);
     }
     console.log(`[${this.getKSTTime()}] notifyPRUpdates 완료`);
@@ -192,7 +192,7 @@ class MattermostNotifier {
                 short: false
             }
         ];
-        await this.sendMattermostMessage({ text: message, fields });
+        await this.sendMattermostMessage({ text: message, fields }, 'pr');
         await this.markAsNotified('pr_reviews', review.id);
     }
     console.log(`[${this.getKSTTime()}] notifyPRReviews 완료`);
@@ -231,7 +231,7 @@ class MattermostNotifier {
                 short: false
             }
         ];
-        await this.sendMattermostMessage({ text: message, fields });
+        await this.sendMattermostMessage({ text: message, fields }, 'pr');
         await this.markAsNotified('pr_events', pr.id);
     }
     console.log(`[${this.getKSTTime()}] notifyMergedPRs 완료`);
@@ -265,7 +265,7 @@ class MattermostNotifier {
                 short: false
             }
         ];
-        await this.sendMattermostMessage({ text: message, fields });
+        await this.sendMattermostMessage({ text: message, fields }, 'ci');
         await this.markAsNotified('github_action_events', ghActions.id);
     }
     console.log(`[${this.getKSTTime()}] notifyFailedBuilds 완료`);
@@ -274,7 +274,7 @@ class MattermostNotifier {
   private async notifyAlarmFinished() {
     console.log(`[${this.getKSTTime()}] notifyAlarmFinished 시작`);
     try {
-      const channels = await this.getActiveChannels();
+      const channels = await this.getChannelsByType('pr');
 
       // 현재 시간을 기준으로 알람이 완료되었다는 메시지를 보냅니다.
       // 다음 알람 시간을 메세지로 알려줍니다.
@@ -298,20 +298,20 @@ class MattermostNotifier {
   }
   }
 
-  private async getActiveChannels(): Promise<string[]> {
+  private async getChannelsByType(type: string): Promise<string[]> {
     const query = `
-      SELECT channel_id 
-      FROM mattermost_channels 
-      WHERE active = true
+      SELECT channel_id
+      FROM mattermost_channels
+      WHERE active = true AND channel_type = $1
     `;
-    const { rows } = await this.pool.query(query);
+    const { rows } = await this.pool.query(query, [type]);
     return rows.map((row: { channel_id: string }) => row.channel_id);
   }
 
-  private async sendMattermostMessage(message: { text: string; fields: Array<{ title: string; value: string; short: boolean }> }) {
+  private async sendMattermostMessage(message: { text: string; fields: Array<{ title: string; value: string; short: boolean }> }, type: string = 'pr') {
     console.log(`[${this.getKSTTime()}] sendMattermostMessage 시작`);
     try {
-        const channels = await this.getActiveChannels();
+        const channels = await this.getChannelsByType(type);
 
         for (const channelId of channels) {
             await axios.post(`${process.env.MATTERMOST_SERVER_URL}/api/v4/posts`, {

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -115,10 +115,14 @@ CREATE TABLE IF NOT EXISTS mattermost_channels (
 );
 
 CREATE INDEX IF NOT EXISTS idx_mattermost_channels_team_name ON mattermost_channels(team_name);
-CREATE INDEX IF NOT EXISTS idx_mattermost_channels_channel_type ON mattermost_channels(channel_type);
+
 
 INSERT INTO mattermost_channels (channel_id, team_name, channel_type)
 VALUES ('e5mz14djfif18rftxfshgdy8xr', 'firstteam', 'pr');
+
+ALTER TABLE mattermost_channels
+  ADD COLUMN IF NOT EXISTS channel_type VARCHAR(20) NOT NULL DEFAULT 'pr';
+CREATE INDEX IF NOT EXISTS idx_mattermost_channels_channel_type ON mattermost_channels(channel_type);
 
 
 ALTER TABLE pr_events ADD COLUMN IF NOT EXISTS comment_content TEXT;

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -108,15 +108,17 @@ CREATE TABLE IF NOT EXISTS mattermost_channels (
     id SERIAL PRIMARY KEY,
     channel_id VARCHAR(100) NOT NULL,
     team_name VARCHAR(100) NOT NULL,
+    channel_type VARCHAR(20) NOT NULL DEFAULT 'pr',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     active BOOLEAN DEFAULT true,
     UNIQUE(channel_id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_mattermost_channels_team_name ON mattermost_channels(team_name);
+CREATE INDEX IF NOT EXISTS idx_mattermost_channels_channel_type ON mattermost_channels(channel_type);
 
-INSERT INTO mattermost_channels (channel_id, team_name) 
-VALUES ('e5mz14djfif18rftxfshgdy8xr', 'firstteam');
+INSERT INTO mattermost_channels (channel_id, team_name, channel_type)
+VALUES ('e5mz14djfif18rftxfshgdy8xr', 'firstteam', 'pr');
 
 
 ALTER TABLE pr_events ADD COLUMN IF NOT EXISTS comment_content TEXT;


### PR DESCRIPTION
## Summary
- support separate Mattermost channels for PR-related and CI/CD notifications
- send CI builds to `ci` channels and PR events to `pr` channels
- document the new `channel_type` column in README

## Testing
- `npm run build` in `github-crawler`
- `npm run build` in `mattermost-notifier`
- `npm run build` in `scheduler`


------
https://chatgpt.com/codex/tasks/task_e_68414f6a9f54832cbada041d254b075d