### PR TITLE
Add English README and keep Korean version

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -1,0 +1,98 @@
+# Mattermost github alarm bot
+
+## Prerequisites
+- docker
+- docker-compose
+
+## 환경 설정
+
+프로젝트를 실행하기 전에 `.env` 파일을 생성하고 다음과 같은 환경변수들을 설정해야 합니다:
+
+```env
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=postgres
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432 
+GITHUB_TOKEN=your_github_token
+MATTERMOST_BOT_TOKEN=your_mattermost_bot_token
+MATTERMOST_SERVER_URL=http://your_mattermost_server
+JWT_SECRET=your_jwt_secret
+CRON_SCHEDULE='0 8-18 * * 1-5'  # 매 정시 실행, 주중(월~금) 8시부터 18시까지만 실행
+```
+
+각 환경변수 설정 방법:
+- `GITHUB_TOKEN`: GitHub Personal Access Token을 발급받아 입력
+- `JWT_SECRET`: JWT 토큰 생성을 위한 비밀키 설정
+- `CRON_SCHEDULE`: 알림 체크 주기 설정 (기본값: 1분)
+- `MATTERMOST_BOT_TOKEN` : 알림을 위한 review bot의 token
+- `MATTERMOST_SERVER_URL` : mattermost 서버 도메인 주소
+
+## 시스템 구조
+
+이 프로젝트는 다음과 같은 주요 컴포넌트로 구성되어 있습니다:
+
+### 1. GitHub Crawler (github-crawler/src/githubCrawler.ts)
+- GitHub API를 사용하여 지정된 저장소의 PR과 워크플로우 상태를 모니터링
+- 주요 기능:
+  - PR 생성/수정/리뷰/머지 이벤트 감지
+  - GitHub Actions 워크플로우 실행 결과 모니터링
+  - 모든 이벤트를 PostgreSQL 데이터베이스에 저장
+
+### 2. Mattermost Notifier (mattermost-notifier/src/mattermostNotifier.ts)
+- 데이터베이스에 저장된 이벤트를 기반으로 Mattermost에 알림 전송
+- 알림 종류:
+  - 새로운 PR 생성
+  - PR 코드 업데이트
+  - PR 리뷰 등록
+  - PR 머지 완료
+  - GitHub Actions 빌드 실패
+
+### 3. 데이터베이스 (PostgreSQL)
+- 이벤트 데이터 저장
+- 테이블 구조:
+  - github_repositories: 모니터링할 저장소 정보
+  - pr_events: PR 관련 이벤트
+  - pr_reviews: PR 리뷰 정보
+  - github_action_events: GitHub Actions 실행 결과
+  - crawler_status: 크롤링 상태 정보
+  - mattermost_channels: Mattermost 채널 정보 (channel_type 컬럼을 통해 PR 채널과 CI/CD 채널을 구분)
+
+### 4. API (PostgREST)
+- 데이터베이스 REST API 제공
+- Swagger UI를 통한 API 문서화
+
+### 5. 스케줄러
+- 설정된 주기(CRON_SCHEDULE)에 따라 크롤링 및 알림 전송 작업 실행
+
+## 알림 기능
+
+1. PR 관련 알림:
+   - 🆕 새로운 PR 생성
+   - 📝 PR 코드 업데이트
+   - 💬 PR 작성자 코멘트
+   - 👀 PR 리뷰 (✅ 승인, ❌ 변경 요청, 💭 코멘트)
+   - 🎉 PR 머지 완료
+
+2. GitHub Actions 관련 알림:
+   - ❌ CI/CD 빌드 실패
+
+## 실행 방법
+
+```bash
+# 프로젝트 실행
+docker-compose up -d
+
+# DB 초기화 또는 스키마 변경 적용
+docker-compose run --rm db-init
+
+# 로그 확인
+docker-compose logs -f
+
+# 프로젝트 중지
+docker-compose down
+```
+
+## API 문서
+- Swagger UI: http://localhost:8080
+- PostgREST API: http://localhost:3002

--- a/README.md
+++ b/README.md
@@ -1,98 +1,96 @@
-# Mattermost github alarm bot
+# Mattermost GitHub Alarm Bot
 
 ## Prerequisites
 - docker
 - docker-compose
 
-## 환경 설정
-
-프로젝트를 실행하기 전에 `.env` 파일을 생성하고 다음과 같은 환경변수들을 설정해야 합니다:
+## Environment Setup
+Before running the project, create a `.env` file and define the following variables:
 
 ```env
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_DB=postgres
 POSTGRES_HOST=localhost
-POSTGRES_PORT=5432 
+POSTGRES_PORT=5432
 GITHUB_TOKEN=your_github_token
 MATTERMOST_BOT_TOKEN=your_mattermost_bot_token
 MATTERMOST_SERVER_URL=http://your_mattermost_server
 JWT_SECRET=your_jwt_secret
-CRON_SCHEDULE='0 8-18 * * 1-5'  # 매 정시 실행, 주중(월~금) 8시부터 18시까지만 실행
+CRON_SCHEDULE='0 8-18 * * 1-5'  # every hour on weekdays 8am-6pm
 ```
 
-각 환경변수 설정 방법:
-- `GITHUB_TOKEN`: GitHub Personal Access Token을 발급받아 입력
-- `JWT_SECRET`: JWT 토큰 생성을 위한 비밀키 설정
-- `CRON_SCHEDULE`: 알림 체크 주기 설정 (기본값: 1분)
-- `MATTERMOST_BOT_TOKEN` : 알림을 위한 review bot의 token
-- `MATTERMOST_SERVER_URL` : mattermost 서버 도메인 주소
+Variable details:
+- `GITHUB_TOKEN`: GitHub Personal Access Token
+- `JWT_SECRET`: secret key for generating JWT tokens
+- `CRON_SCHEDULE`: check interval for notifications (default: 1 minute)
+- `MATTERMOST_BOT_TOKEN`: token for the review bot
+- `MATTERMOST_SERVER_URL`: domain of the Mattermost server
 
-## 시스템 구조
+## System Overview
+This project consists of the following components:
 
-이 프로젝트는 다음과 같은 주요 컴포넌트로 구성되어 있습니다:
+### 1. GitHub Crawler (`github-crawler/src/githubCrawler.ts`)
+- Monitors PRs and workflow status of specified repositories via the GitHub API
+- Key features:
+  - Detects PR create/update/review/merge events
+  - Monitors GitHub Actions workflow results
+  - Stores all events in a PostgreSQL database
 
-### 1. GitHub Crawler (github-crawler/src/githubCrawler.ts)
-- GitHub API를 사용하여 지정된 저장소의 PR과 워크플로우 상태를 모니터링
-- 주요 기능:
-  - PR 생성/수정/리뷰/머지 이벤트 감지
-  - GitHub Actions 워크플로우 실행 결과 모니터링
-  - 모든 이벤트를 PostgreSQL 데이터베이스에 저장
+### 2. Mattermost Notifier (`mattermost-notifier/src/mattermostNotifier.ts`)
+- Sends notifications to Mattermost based on events saved in the database
+- Notification types:
+  - New PR creation
+  - PR code updates
+  - PR reviews
+  - PR merge completion
+  - GitHub Actions build failures
 
-### 2. Mattermost Notifier (mattermost-notifier/src/mattermostNotifier.ts)
-- 데이터베이스에 저장된 이벤트를 기반으로 Mattermost에 알림 전송
-- 알림 종류:
-  - 새로운 PR 생성
-  - PR 코드 업데이트
-  - PR 리뷰 등록
-  - PR 머지 완료
-  - GitHub Actions 빌드 실패
-
-### 3. 데이터베이스 (PostgreSQL)
-- 이벤트 데이터 저장
-- 테이블 구조:
-  - github_repositories: 모니터링할 저장소 정보
-  - pr_events: PR 관련 이벤트
-  - pr_reviews: PR 리뷰 정보
-  - github_action_events: GitHub Actions 실행 결과
-  - crawler_status: 크롤링 상태 정보
-  - mattermost_channels: Mattermost 채널 정보 (channel_type 컬럼을 통해 PR 채널과 CI/CD 채널을 구분)
+### 3. Database (PostgreSQL)
+- Stores event data
+- Tables:
+  - `github_repositories`: repositories to monitor
+  - `pr_events`: PR-related events
+  - `pr_reviews`: PR review information
+  - `github_action_events`: GitHub Actions results
+  - `crawler_status`: crawler status information
+  - `mattermost_channels`: Mattermost channel data (`channel_type` differentiates PR and CI/CD channels)
 
 ### 4. API (PostgREST)
-- 데이터베이스 REST API 제공
-- Swagger UI를 통한 API 문서화
+- Provides a REST API for the database
+- API documentation via Swagger UI
 
-### 5. 스케줄러
-- 설정된 주기(CRON_SCHEDULE)에 따라 크롤링 및 알림 전송 작업 실행
+### 5. Scheduler
+- Runs crawling and notification tasks according to `CRON_SCHEDULE`
 
-## 알림 기능
+## Notification Features
+1. PR Notifications:
+   - 🆕 New PR created
+   - 📝 PR code updated
+   - 💬 Comment from PR author
+   - 👀 PR review (✅ approve, ❌ request changes, 💭 comment)
+   - 🎉 PR merged
 
-1. PR 관련 알림:
-   - 🆕 새로운 PR 생성
-   - 📝 PR 코드 업데이트
-   - 💬 PR 작성자 코멘트
-   - 👀 PR 리뷰 (✅ 승인, ❌ 변경 요청, 💭 코멘트)
-   - 🎉 PR 머지 완료
+2. GitHub Actions Notifications:
+   - ❌ CI/CD build failed
 
-2. GitHub Actions 관련 알림:
-   - ❌ CI/CD 빌드 실패
-
-## 실행 방법
-
+## Usage
 ```bash
-# 프로젝트 실행
+# Start the project
 docker-compose up -d
 
-# DB 초기화 또는 스키마 변경 적용
+# Initialize the DB or apply schema changes
 docker-compose run --rm db-init
 
-# 로그 확인
+# View logs
 docker-compose logs -f
 
-# 프로젝트 중지
+# Stop the project
 docker-compose down
 ```
 
-## API 문서
+## API Documentation
 - Swagger UI: http://localhost:8080
 - PostgREST API: http://localhost:3002
+
+For the original Korean documentation, see [README.kr.md](README.kr.md).


### PR DESCRIPTION
## Summary
- provide English documentation as README.md
- move the previous Korean README to README.kr.md

## Testing
- `npm test` in `github-crawler`
- `npm test` in `mattermost-notifier`
- `npm test` in `scheduler`


------
https://chatgpt.com/codex/tasks/task_e_6842c73f6020832c8fff3ab0895a9888