### PR TITLE
Fix CI tracking to ignore old failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ This project consists of the following components:
    - 🎉 PR merged
 
 2. GitHub Actions Notifications:
-   - ❌ CI/CD build failed
+ - ❌ CI/CD build failed
+    - Only the latest workflow result for each PR is considered. If a newer run succeeds, previous failures are ignored.
 
 ## Usage
 ```bash

--- a/github-crawler/src/githubCrawler.ts
+++ b/github-crawler/src/githubCrawler.ts
@@ -153,9 +153,19 @@ class GithubCrawler {
       const filteredRuns = workflows.workflow_runs.filter((run: any) => new Date(run.created_at) >= cutoffTime);
       console.log(`[${this.getKSTTime()}] [monitorWorkflowRuns] 워크플로우 실행 개수: ${workflows.workflow_runs.length}, 필터링된 실행 개수: ${filteredRuns.length}`);
 
+      const latestRuns: Record<string, any> = {};
       for (const run of filteredRuns) {
+        const key = `${run.workflow_id}-${run.head_branch}`;
+        if (!latestRuns[key] || new Date(run.created_at) > new Date(latestRuns[key].created_at)) {
+          latestRuns[key] = run;
+        }
+      }
+
+      for (const run of Object.values(latestRuns)) {
         if (run.conclusion === 'failure') {
           await this.handleGithubActionFailed(run);
+        } else {
+          console.log(`[${this.getKSTTime()}] [monitorWorkflowRuns] 최신 실행 ${run.id} 성공, 이전 실패 무시`);
         }
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
- track only the most recent workflow run per branch
- document that older failures are ignored when a newer run succeeds

## Testing
- `npm run build` in packages
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ccbc2ac60832c9d468ebbbfdd0f41